### PR TITLE
Increased usability with tab order and page zoom

### DIFF
--- a/includes/VectorTemplate.php
+++ b/includes/VectorTemplate.php
@@ -59,11 +59,6 @@ class VectorTemplate extends BaseTemplate {
 		?>
 		<div class="collab-fip-header" style="height:35px; clear:both; background-color:white;">
 			<object type="image/svg+xml" tabindex="-1" role="img" data="<?php echo $wgScriptPath; ?>/skins/Vector/images/collab/sig-alt-en.svg" aria-label="Symbol of the Government of Canada" style="height:25px; float:left; padding:5px 10px;"></object>
-			<ul id="tool-links" class="" style="list-style:none; padding:5px; width:30%; margin: 0 auto; font-weight:bold;">
-				<li style="float:left; margin: 0px 2%;"><a href="https://account.gccollab.ca" style="color:#6b5088;"><span><img style="width:25px; display:inline-block; margin-right:3px;" src="<?php echo $wgScriptPath . '/skins/Vector/images/collab/mini_wiki_icon.png'; ?>" alt=""></span><?php global $wgLang; if ($wgLang->getCode() == 'fr') echo  'GCcompte'; else echo 'GCaccount'; ?></a></li>
-				<li style="float:left; margin: 0px 2%;"><a href="https://gccollab.ca/" style="color:#6b5088;"><span><img style="width:25px; display:inline-block; margin-right:3px;" src="<?php echo $wgScriptPath . '/skins/Vector/images/collab/mini_collab_icon.png'; ?>" alt=""></span>GCcollab</a></li>
-				<li style="float:left; margin: 0px 2%;"><a href="https://message.gccollab.ca/" style="color:#6b5088;"><span><img style="width:25px; display:inline-block; margin-right:3px;" src="<?php echo $wgScriptPath . '/skins/Vector/images/collab/message_icon.png'; ?>" alt=""></span>GCmessage</a></li>
-			</ul>
 		</div>
 		<div id="mw-page-base" class="noprint"></div>
 		<div id="mw-head-base" class="noprint"></div>
@@ -98,6 +93,13 @@ class VectorTemplate extends BaseTemplate {
 
 			$this->html( 'prebodyhtml' );
 			?>
+			<div id="app-brand-name-mobile"  style="background:#6D4E86; position:absolute; top:2px; clear:both; float:left; font-size:24px; color:white; padding:8px 59px 6px 62px; left: 0;">
+				<a class="mw-wiki-logo" href="<?php
+				echo htmlspecialchars( $this->data['nav_urls']['mainpage']['href'] )
+				?>">
+					<span style="font-weight:600">GC</span>wiki
+				</a>
+			</div>
 			<div id="bodyContent" class="mw-body-content">
 				<?php
 				if ( $this->data['isarticle'] ) {
@@ -162,13 +164,23 @@ class VectorTemplate extends BaseTemplate {
 		<div id="mw-navigation">
 			<h2><?php $this->msg( 'navigation-heading' ) ?></h2>
 
-			<div id="mw-head" style="top:35px;">
+			<div id="mw-head">
 				<style>
 					#app-brand-name:before{
-						content: ''; display: block; position: absolute; left: 166px; top: 0; width: 0; height: 0; border-top: 20px solid transparent; border-bottom: 22px solid transparent; border-left: 20px solid #6D4E86; clear: both;
+						content: ''; display: block; position: absolute; left: 197px; top: 0; width: 0; height: 0; border-top: 20px solid transparent; border-bottom: 22px solid transparent; border-left: 20px solid #6D4E86; clear: both;
+					}
+					#app-brand-name-mobile:before{
+						content: ''; display: block; position: absolute; left: 197px; top: 0; width: 0; height: 0; border-top: 20px solid transparent; border-bottom: 22px solid transparent; border-left: 20px solid #6D4E86; clear: both;
+					}
+					#app-brand-name-mobile {
+						display:none;
+					}
+					#app-brand-name-mobile a {
+						text-decoration: none;
+						color:white;
 					}
 				</style>
-				<div id="app-brand-name"  style="background:#6D4E86; position:absolute; top:2px; clear:both; float:left; font-size:24px; color:white; padding:8px 59px 6px 62px;"><span style="font-weight:800">GC</span>wiki</div>
+				<div id="app-brand-name"  style="background:#6D4E86; position:absolute; top:2px; clear:both; float:left; font-size:24px; color:white; padding:8px 59px 6px 62px;"><span style="font-weight:600">GC</span>wiki</div>
 
 				<?php $this->renderNavigation( [ 'PERSONAL' ] ); ?>
 				<div id="left-navigation">
@@ -185,10 +197,17 @@ class VectorTemplate extends BaseTemplate {
 					?>" <?php
 					echo Xml::expandAttributes( Linker::tooltipAndAccesskeyAttribs( 'p-logo' ) )
 					?>>
-					<img src="<?php global $wgLang; if ($wgLang->getCode() == 'fr') echo $wgScriptPath . '/skins/Vector/images/collab/collab_logo_fr.png'; else echo $wgScriptPath .'/skins/Vector/images/collab/collab_logo_en.png'; ?>" type="image/png" style="width:100%;">
+					<img alt="GCwiki" src="<?php global $wgLang; if ($wgLang->getCode() == 'fr') echo $wgScriptPath . '/skins/Vector/images/collab/collab_logo_fr.png'; else echo $wgScriptPath .'/skins/Vector/images/collab/collab_logo_en.png'; ?>" type="image/png" style="width:100%;">
 				</a>
 				</div>
 				<?php $this->renderPortals( $this->data['sidebar'] ); ?>
+				<nav>
+					<ul id="tool-links" class="" style="list-style:none; padding:5px; margin: 0 auto; font-weight:bold;">
+						<li style="float:left; margin: 3px 2%;"><a href="https://account.gccollab.ca" style="color:#6b5088;"><span><img style="width:25px; display:inline-block; margin-right:3px;" src="<?php echo $wgScriptPath . '/skins/Vector/images/collab/mini_wiki_icon.png'; ?>" alt=""></span><?php global $wgLang; if ($wgLang->getCode() == 'fr') echo  'GCcompte'; else echo 'GCaccount'; ?></a></li>
+						<li style="float:left; margin: 3px 2%;"><a href="https://gccollab.ca/" style="color:#6b5088;"><span><img style="width:25px; display:inline-block; margin-right:3px;" src="<?php echo $wgScriptPath . '/skins/Vector/images/collab/mini_collab_icon.png'; ?>" alt=""></span>GCcollab</a></li>
+						<li style="float:left; margin: 3px 2%;"><a href="https://message.gccollab.ca/" style="color:#6b5088;"><span><img style="width:25px; display:inline-block; margin-right:3px;" src="<?php echo $wgScriptPath . '/skins/Vector/images/collab/message_icon.png'; ?>" alt=""></span>GCmessage</a></li>
+					</ul>
+				</nav>
 			</div>
 		</div>
 		<?php Hooks::run( 'VectorBeforeFooter' ); ?>

--- a/responsive.less
+++ b/responsive.less
@@ -157,4 +157,18 @@ div#mw-head {
 	#app-brand-name {
 		display:none;
 	}
+	
+	/* language menu */
+	.uls-wide {
+		min-width: unset !important;
+		max-width: 100%;
+		left: 10px !important;
+	}
+
+	.grid .row {
+		width:210% !important;
+		max-width: unset !important;
+		min-width: unset !important;
+		margin: 0 auto;
+	}
 }

--- a/responsive.less
+++ b/responsive.less
@@ -4,10 +4,22 @@
 	left for it.
 */
 
-@media screen and ( max-width: @deviceWidthTablet ) {
+div#mw-head {
+	top: 35px;
+}
+
+#ca-favorite a:focus,
+#ca-unfavorite a:focus,
+#searchInput:focus {
+	outline: -webkit-focus-ring-color auto 1px !important;
+}
+
+@media screen and ( max-width: 768px ) {
 	div#mw-head {
 		position: static !important; /* stylelint-disable-line declaration-no-important */
 		margin-top: 0.5em;
+		top:0;
+		height: 9em;
 	}
 
 	/* Move the panel to the bottom and display it as in-line lists */
@@ -21,8 +33,10 @@
 			font-size: 150%;
 
 			.portal {
-				display: block;
-				width: 100%;
+				display: inline-block;
+				width: 35%;
+				vertical-align: top;
+				margin-top: 0;
 			}
 
 			ul li {
@@ -50,7 +64,7 @@
 	div#p-personal {
 		display: table;
 		position: relative;
-		width: 100%;
+		margin: 0 auto;
 		top: inherit;
 		left: inherit;
 		right: inherit;
@@ -61,40 +75,43 @@
 	}
 	div#right-navigation {
 		position: absolute;
-		top: inherit;
+		max-width: 435px;
 		right: 0;
 		margin-top: 0;
 		float: none;
 	}
 	div#left-navigation {
 		position: absolute;
-		top: inherit;
+
 		margin: 0;
 		display: block;
 		float: none;
 	}
+
 	div#p-namespaces,
 	div#p-views,
 	div#p-variants {
 		position: relative;
-		top: 2.5em;
+		top: 1em;
 	}
+
 	div#p-namespaces {
 		padding-left: 0;
 	}
 	div#p-cactions {
-		top: 2.5em;
+		top: 1em;
 		float: right;
 	}
 	div#p-search {
 		float: none;
 		position: absolute;
 		right: 0;
+		top: 65px;
 		width: 100vw;
 		margin: 0;
 	}
 	div#simpleSearch {
-		margin: 0 3em;
+		margin: 0 auto;
 		width: 80vw;
 		padding: 0;
 	}
@@ -106,5 +123,38 @@
 		/* Hide the 1px blue border on the left side */
 		border-left: 0;
 		margin-left: 0;
+	}
+
+	div.collab-fip-header {
+		display: none;
+	}
+
+	div.vectorTabs,
+	div.vectorTabs ul,
+	div.vectorTabs span,
+	div.vectorTabs li.selected,
+	div.vectorTabs ul li {
+		background-image: none;
+	}
+
+	div.vectorMenu #ca-favorite a,
+	div.vectorMenu #ca-unfavorite a {
+		padding-top: 1.2em;
+	}
+
+	#tool-links {
+		margin: 1em 0;
+	}
+
+	#app-brand-name-mobile {
+		display:block !important;
+	}
+
+	#app-brand-name-mobile a:focus {
+		outline: -webkit-focus-ring-color auto 1px !important;
+	}
+
+	#app-brand-name {
+		display:none;
 	}
 }

--- a/skin.json
+++ b/skin.json
@@ -102,7 +102,7 @@
 	"config": {
 		"VectorUseSimpleSearch": true,
 		"VectorUseIconWatch": true,
-		"VectorResponsive": false,
+		"VectorResponsive": true,
 		"VectorPrintLogo": false
 	},
 	"manifest_version": 1

--- a/vector.js
+++ b/vector.js
@@ -20,10 +20,14 @@ jQuery( function ( $ ) {
 
 	rAF( initialCactionsWidth );
 
-	/**
-	 * Focus search input at the very end
-	 */
-	$( '#searchInput' ).attr( 'tabindex', $( document ).lastTabIndex() + 1 );
+	//add text to favourite button
+	if(mw.config.get( 'wgUserLanguage' ) == "fr"){
+		$('#ca-favorite.icon a').text('Ajouter cette page à vos favoris');
+		$('#ca-unfavorite.icon a').text('Supprimer cette page de vos favoris');
+	} else {
+		$('#ca-favorite.icon a').text('Add this page to your favorites');
+		$('#ca-unfavorite.icon a').text('Remove this page from your favorites');
+	}
 
 	// Bind callback functions to animate our drop down menu in and out
 	// and then call the collapsibleTabs function on the menu


### PR DESCRIPTION
To address the issues with tab order and page zoom, the vector theme of GCwiki has had responsiveness enabled. 

Other changes:
- Added focus to links that were missing focus state
- Added a home link to the top of the zoomed in page for easier navigation
- Changed some styling around the navigation when  zoomed in 

gctools-outilsgc/gcconnex#2223
gctools-outilsgc/gcpedia#139
gctools-outilsgc/gcpedia#137